### PR TITLE
Added instructions for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,3 @@ npm run compile
 
 npm start
 ```
-
-Note: Windows users should replace the start script *line 8* in **package.json** with 
-```
-set NODE_ENV=development && node ./lib/app.js
-```
-before running `npm start`.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ npm run compile
 
 npm start
 ```
+
+Note: Windows users should replace the start script *line 8* in **package.json** with 
+```
+set NODE_ENV=development && node ./lib/app.js
+```
+before running `npm start`.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/app.js",
   "author": "Paul Pagnan <paul@pagnan.com.au>",
   "scripts": {
-    "start": "NODE_ENV=development node ./lib/app.js",
+    "start": "node ./lib/app.js",
     "compile": "babel -d lib/ src/",
     "run": "babel -d lib/ src/ && node lib/app"
   },


### PR DESCRIPTION
Modified README.md to include instructions for Windows users to add 'set'
and '&&' to the start script in package.json in order to avoid the
 'NODE_ENV' is not recognized... error.
Changes to be committed:
	modified:   README.md